### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ and requires Postgresql 9.1.
   :target: https://coveralls.io/r/seantis/libres
   :alt:    coveralls.io coverage
 
-.. image:: https://pypip.in/v/libres/badge.png
+.. image:: https://img.shields.io/pypi/v/libres.svg
     :target: https://pypi.python.org/pypi/libres
     :alt: Latest PyPI release
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20libres))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `libres`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.